### PR TITLE
[Feat] #41 UI 자잘하게 수정 및 실수 정정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,9 @@ class Hanbae extends StatelessWidget {
       theme: ThemeData.dark().copyWith( // ThemeData.dark()를 유지하면서
         scaffoldBackgroundColor:
             AppColors.backgroundDefault, // scaffold 배경색을 오버라이드
+        appBarTheme: const AppBarTheme(
+          backgroundColor: AppColors.backgroundNavigationbar,
+        ),
         textTheme: ThemeData.dark().textTheme.apply(fontFamily: 'Pretendard'),
       ),
       home: HomeScreen(),

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -16,6 +16,7 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: AppColors.backgroundDefault,
         leading: Container(
           margin: const EdgeInsets.only(left: 16),
           child: SizedBox(
@@ -30,32 +31,44 @@ class HomeScreen extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Column(
             children: [
-              Image.asset("assets/images/banner/SurveyBanner.png"),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Image.asset("assets/images/banner/SurveyBanner.png"),
+              ),
+
+              const SizedBox(height: 24),
+
               Column(
                 children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        "내가 저장한 장단",
-                        style: AppTextStyles.title2B.copyWith(
-                          color: AppColors.textDefault,
-                        ),
-                      ),
-                      TextButton(
-                        onPressed: () {},
-                        style: TextButton.styleFrom(minimumSize: Size(0, 40)),
-                        child: Text(
-                          "더보기",
-                          style: AppTextStyles.calloutR.copyWith(
-                            color: AppColors.textTertiary,
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          "내가 저장한 장단",
+                          style: AppTextStyles.title2B.copyWith(
+                            color: AppColors.textDefault,
                           ),
                         ),
-                      ),
-                    ],
+                        TextButton(
+                          onPressed: () {},
+                          style: TextButton.styleFrom(
+                            minimumSize: Size(40, 40),
+                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                            padding: EdgeInsets.zero,),
+                          child: Text(
+                            "더보기",
+                            style: AppTextStyles.calloutR.copyWith(
+                              color: AppColors.textTertiary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
 
-                  SizedBox(height: 16),
+                  const SizedBox(height: 8),
 
                   SizedBox(
                     height: 84,
@@ -155,20 +168,26 @@ class HomeScreen extends StatelessWidget {
 
               Column(
                 children: [
-                  Row(
-                    children: [
-                      Text(
-                        "바로 연습하기",
-                        style: TextStyle(
-                          fontSize: 22,
-                          fontWeight: FontWeight.bold,
-                          color: AppColors.textDefault,
-                        ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: SizedBox(
+                      height: 40,
+                      child: Row(
+                        children: [
+                          Text(
+                            "바로 연습하기",
+                            style: TextStyle(
+                              fontSize: 22,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.textDefault,
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
+                    ),
                   ),
 
-                  SizedBox(height: 16),
+                  SizedBox(height: 8),
 
                   ListView.separated(
                     shrinkWrap: true,

--- a/lib/presentation/metronome/metronome_control.dart
+++ b/lib/presentation/metronome/metronome_control.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hanbae/theme/colors.dart';
 import 'package:hanbae/theme/text_styles.dart';
-import 'package:hanbae/model/jangdan.dart';
 import 'package:flutter_bloc/flutter_bloc.dart'; // Import the flutter_bloc package
 import 'package:hanbae/bloc/metronome/metronome_bloc.dart'; // Import the MetronomeBloc
 
@@ -75,6 +74,7 @@ class MetronomeControl extends StatelessWidget {
                                 fontSize: 64,
                                 fontWeight: FontWeight.w500,
                                 color: AppColors.textButtonSecondary,
+                                letterSpacing: -0.5
                               ),
                             ),
                           ),
@@ -123,7 +123,7 @@ class MetronomeControl extends StatelessWidget {
                             "시작",
                             style: TextStyle(
                               fontSize: 34,
-                              fontWeight: FontWeight.w600,
+                              fontWeight: FontWeight.w500,
                               color: AppColors.textButtonEmphasis,
                             ),
                           ),
@@ -141,6 +141,7 @@ class MetronomeControl extends StatelessWidget {
                           textAlign: TextAlign.center,
                           style: AppTextStyles.bodyR.copyWith(
                             color: AppColors.textButtonPrimary,
+                            height: 1.12
                           ),
                         ),
                       ),

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -50,7 +50,7 @@ class MetronomeScreen extends StatelessWidget {
           ),
           BlocBuilder<MetronomeBloc, MetronomeState>(
             builder: (context, state) {
-              return MetronomeControl(jangdan: state.selectedJangdan);
+              return MetronomeControl();
             },
           )
         ],

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -5,6 +5,8 @@ import 'package:hanbae/presentation/metronome/hanbae_board.dart';
 import 'package:hanbae/presentation/metronome/metronome_control.dart';
 import 'package:hanbae/presentation/metronome/metronome_setting_control.dart';
 import 'package:hanbae/bloc/metronome/metronome_bloc.dart';
+import 'package:hanbae/theme/colors.dart';
+import 'package:hanbae/theme/text_styles.dart';
 
 class MetronomeScreen extends StatelessWidget {
   const MetronomeScreen({super.key, required this.jangdan});
@@ -21,7 +23,7 @@ class MetronomeScreen extends StatelessWidget {
           },
           icon: Icon(Icons.chevron_left),
         ),
-        title: Text(jangdan.name),
+        title: Text(jangdan.name, style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary,)),
         centerTitle: true,
         actions: [
           IconButton(onPressed: () {}, icon: Icon(Icons.replay)),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,7 +106,7 @@ flutter:
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/to/font-from-package
 
-fonts:
+  fonts:
     - family: Pretendard
       fonts:
         - asset: assets/fonts/Pretendard-Thin.ttf


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
ui 수정 및 실수 정정

<!-- Close #41 -->

## 작업 내용
### 1. mian theme 에서 appbar 컬러 고정

### 2. 폰트 적용
yaml파일 들여쓰기 오류로 폰트 적용안됐던거 정정

### 3. 홈 스크린 ui 수정

### 4. 메트로놈 스크린 변수 삭제, 폰트 스타일 수정


## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?