### PR TITLE
[Feat] #33 메트로놈 초기화

### DIFF
--- a/lib/bloc/metronome/metronome_bloc.dart
+++ b/lib/bloc/metronome/metronome_bloc.dart
@@ -45,6 +45,15 @@ class MetronomeBloc extends Bloc<MetronomeEvent, MetronomeState> {
       );
     });
 
+    on<ResetMetronome>((event, emit) {
+      final jangdan = state.selectedJangdan;
+      final original = basicJangdanData[jangdan.jangdanType.name] ?? jangdan;
+      emit(state.copyWith(
+        selectedJangdan: original,
+        bpm: original.bpm,
+      ));
+    });
+
     on<Play>((event, emit) {
       final jangdan = state.selectedJangdan;
       final lastRowIndex = jangdan.accents.length - 1;

--- a/lib/bloc/metronome/metronome_bloc.dart
+++ b/lib/bloc/metronome/metronome_bloc.dart
@@ -47,7 +47,7 @@ class MetronomeBloc extends Bloc<MetronomeEvent, MetronomeState> {
 
     on<ResetMetronome>((event, emit) {
       final jangdan = state.selectedJangdan;
-      final original = basicJangdanData[jangdan.jangdanType.name] ?? jangdan;
+      final original = basicJangdanData[jangdan.name] ?? jangdan;
       emit(state.copyWith(
         selectedJangdan: original,
         bpm: original.bpm,

--- a/lib/bloc/metronome/metronome_event.dart
+++ b/lib/bloc/metronome/metronome_event.dart
@@ -53,3 +53,7 @@ class ChangeSound extends MetronomeEvent {
   @override
   List<Object?> get props => [sound];
 }
+
+class ResetMetronome extends MetronomeEvent {
+  const ResetMetronome();
+}

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -23,19 +23,12 @@ class MetronomeScreen extends StatelessWidget {
           },
           icon: Icon(Icons.chevron_left),
         ),
-        title: Text(jangdan.name, style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary,)),
+        title: Text(
+          jangdan.name,
+          style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary),
+        ),
         centerTitle: true,
-        actions: [
-          IconButton(onPressed: () {}, icon: Icon(Icons.replay)),
-          PopupMenuButton(
-            icon: Icon(Icons.upload),
-            itemBuilder: (context) => <PopupMenuEntry>[
-              PopupMenuItem(child: Text("popupMenu1")),
-              PopupMenuItem(child: Text("popupMenu2")),
-              PopupMenuItem(child: Text("popupMenu3")),
-            ],
-          ),
-        ],
+        actions: [IconButton(onPressed: () {}, icon: Icon(Icons.replay))],
       ),
       body: Column(
         children: [

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hanbae/data/basic_jangdan_data.dart';
 import 'package:hanbae/model/jangdan.dart';
 import 'package:hanbae/presentation/metronome/hanbae_board.dart';
 import 'package:hanbae/presentation/metronome/metronome_control.dart';
@@ -28,7 +29,12 @@ class MetronomeScreen extends StatelessWidget {
           style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary),
         ),
         centerTitle: true,
-        actions: [IconButton(onPressed: () {}, icon: Icon(Icons.replay))],
+        actions: [
+          IconButton(onPressed: () {
+            context.read<MetronomeBloc>().add(SelectJangdan(basicJangdanData[jangdan.jangdanType.name] ?? jangdan));
+        },
+        icon: Icon(Icons.replay))
+        ],
       ),
       body: Column(
         children: [

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hanbae/data/basic_jangdan_data.dart';
 import 'package:hanbae/model/jangdan.dart';
 import 'package:hanbae/presentation/metronome/hanbae_board.dart';
 import 'package:hanbae/presentation/metronome/metronome_control.dart';
@@ -20,7 +19,9 @@ class MetronomeScreen extends StatelessWidget {
         toolbarHeight: 44.0,
         leading: IconButton(
           onPressed: () {
-            Navigator.pop(context); // This will pop the current screen off the navigation stack
+            Navigator.pop(
+              context,
+            ); // This will pop the current screen off the navigation stack
           },
           icon: Icon(Icons.chevron_left),
         ),
@@ -30,10 +31,12 @@ class MetronomeScreen extends StatelessWidget {
         ),
         centerTitle: true,
         actions: [
-          IconButton(onPressed: () {
-            context.read<MetronomeBloc>().add(SelectJangdan(basicJangdanData[jangdan.jangdanType.name] ?? jangdan));
-        },
-        icon: Icon(Icons.replay))
+          IconButton(
+            onPressed: () {
+              context.read<MetronomeBloc>().add(const ResetMetronome());
+            },
+            icon: Icon(Icons.replay),
+          ),
         ],
       ),
       body: Column(
@@ -44,16 +47,14 @@ class MetronomeScreen extends StatelessWidget {
             },
           ),
           Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16.0,
-            ),
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
             child: MetronomeSettingControl(),
           ),
           BlocBuilder<MetronomeBloc, MetronomeState>(
             builder: (context, state) {
               return MetronomeControl();
             },
-          )
+          ),
         ],
       ),
     );


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
메트로놈 화면 상단 초기화 기능을 구현합니다.

<!-- Close #33  -->

## 작업 내용
### 1. 장단 내보내기 삭제
- 커스텀 장단 기능은 추후 구현할거라 일단 삭제함

### 2. 장단 초기화
- 기본값으로 초기화
- basicJangdanData에서 현재 장단과 같은 이름을 찾아 해당 값으로 교체
- 장단 초기화 기능 ResetMetronome 이벤트로 분리
- 나중에 영속성 부여되면 분기처리 하면 될듯

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?