### PR TITLE
[Feat] #51 엇모리 BakbarSet UI 변경

### DIFF
--- a/lib/presentation/metronome/hanbae_board.dart
+++ b/lib/presentation/metronome/hanbae_board.dart
@@ -37,7 +37,8 @@ class HanbaeBoard extends StatelessWidget {
                           .take(rowIndex)
                           .fold<int>(0, (sum, row) => sum + row.length) + daebakIndex;
 
-                        return Expanded(
+                        return Flexible(
+                          flex: daebak.length,
                           child: BakbarSet(
                             daebak: daebak,
                             rowIndex: rowIndex,


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
엇모리 UI 관련 수정입니다.

<!-- Close #51  -->

## 작업 내용
### 1. UI 변경
- 기존 Expanded라서 각 BakbarSet들이 같은 비율을 차지했음
- Flexible로 각자의 소박 갯수에 비례한 크기를 차지하도록 변경함

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->
<img width="612" alt="스크린샷 2025-04-13 오후 9 54 43" src="https://github.com/user-attachments/assets/99139d95-6cd1-4c16-979f-fd52ebcd2a66" />

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?