### PR TITLE
[Feat] #59 메트로놈 화면 빠져나올때 정지

### DIFF
--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -37,48 +37,53 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
         }
       },
       child: Stack(
-    children: [
-      Scaffold(
-      appBar: AppBar(
-        toolbarHeight: 44.0,
-        leading: IconButton(
-          onPressed: () {
-            Navigator.pop(
-              context,
-            ); // This will pop the current screen off the navigation stack
-          },
-          icon: Icon(Icons.chevron_left),
-        ),
-        title: Text(
-          widget.jangdan.name,
-          style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary),
-        ),
-        centerTitle: true,
-        actions: [
-          IconButton(
-            onPressed: () {
-              context.read<MetronomeBloc>().add(const ResetMetronome());
+        children: [
+          PopScope(
+            canPop: true,
+            onPopInvokedWithResult: (bool didPop, result) async {
+              if (didPop == true) {
+                context.read<MetronomeBloc>().add(Stop());
+              }
             },
-            icon: Icon(Icons.replay),
-          ),
-        ],
-      ),
-      body: Column(
-              children: [
-                BlocBuilder<MetronomeBloc, MetronomeState>(
-                  builder: (context, state) => HanbaeBoard(),
+            child: Scaffold(
+              appBar: AppBar(
+                toolbarHeight: 44.0,
+                leading: IconButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  icon: Icon(Icons.chevron_left),
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: MetronomeOptions(),
+                title: Text(
+                  widget.jangdan.name,
+                  style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary),
                 ),
-                BlocBuilder<MetronomeBloc, MetronomeState>(
-                  builder: (context, state) => MetronomeControl(),
-                ),
-              ],
+                centerTitle: true,
+                actions: [
+                  IconButton(
+                    onPressed: () {
+                      context.read<MetronomeBloc>().add(const ResetMetronome());
+                    },
+                    icon: Icon(Icons.replay),
+                  ),
+                ],
+              ),
+              body: Column(
+                children: [
+                  BlocBuilder<MetronomeBloc, MetronomeState>(
+                    builder: (context, state) => HanbaeBoard(),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: MetronomeOptions(),
+                  ),
+                  BlocBuilder<MetronomeBloc, MetronomeState>(
+                    builder: (context, state) => MetronomeControl(),
+                  ),
+                ],
+              ),
             ),
           ),
-
           // 화면반짝임 기능 컬러박스
           Positioned.fill(
             child: IgnorePointer(


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
메트로놈 화면을 벗어날 때 재생중인 메트로놈을 정지합니다

<!-- Close #59  -->

## 작업 내용
### 1. Metronome Screen
- PopScope로 감쌈
- 화면 벗어나는걸 감지해서 Stop 이벤트 호출

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?