### PR TITLE
[Feat] #75 텍스트 크기 고정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,8 @@ class Hanbae extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: ThemeData.dark().copyWith( // ThemeData.dark()를 유지하면서
+      theme: ThemeData.dark().copyWith(
+        // ThemeData.dark()를 유지하면서
         scaffoldBackgroundColor:
             AppColors.backgroundDefault, // scaffold 배경색을 오버라이드
         appBarTheme: const AppBarTheme(
@@ -28,6 +29,14 @@ class Hanbae extends StatelessWidget {
         ),
         textTheme: ThemeData.dark().textTheme.apply(fontFamily: 'Pretendard'),
       ),
+      builder: (context, child) {
+        return MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(textScaler: TextScaler.linear(1.0)),
+          child: child!,
+        );
+      },
       home: HomeScreen(),
     );
   }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
유저가 글자 크기를 키울 때 레이아웃이 깨지는걸 방지하기 위해 폰트 사이즈를 고정합니다.

<!-- Close #75  -->

## 작업 내용
### 1. 텍스트 크기 고정
- 앱 전체에서 TextScaler 1.0으로 고정

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?