### PR TITLE
[Feat] #89 디테일 수정

### DIFF
--- a/lib/presentation/custom_jangdan/custom_jangdan_create_screen.dart
+++ b/lib/presentation/custom_jangdan/custom_jangdan_create_screen.dart
@@ -14,6 +14,7 @@ class CustomJangdanCreateScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        toolbarHeight: 44.0,
         title: Text('내가 저장한 장단', style: TextStyle(fontSize: 17)),
         centerTitle: true,
         backgroundColor: Color(0xFF1F1F1F),

--- a/lib/presentation/custom_jangdan/custom_jangdan_list_screen.dart
+++ b/lib/presentation/custom_jangdan/custom_jangdan_list_screen.dart
@@ -19,6 +19,7 @@ class CustomJangdanListScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: Color(0xFF000000),
       appBar: AppBar(
+        toolbarHeight: 44.0,
         title: Text('내가 저장한 장단', style: TextStyle(fontSize: 17)),
         centerTitle: true,
         backgroundColor: Color(0xFF1F1F1F),

--- a/lib/presentation/custom_jangdan/custom_jangdan_list_screen.dart
+++ b/lib/presentation/custom_jangdan/custom_jangdan_list_screen.dart
@@ -33,22 +33,6 @@ class CustomJangdanListScreen extends StatelessWidget {
                     Navigator.push(context, MaterialPageRoute(builder: (context) => CustomJangdanCreateScreen()));
                   },
                 ),
-                // TextButton(
-                //   style: TextButton.styleFrom(
-                //     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                //     padding: EdgeInsets.zero,
-                //     minimumSize: Size(40, 40),
-                //   ),
-                //   onPressed: () {
-                //     print('TextButton 클릭됨!');
-                //   },
-                //   child: Text(
-                //     '편집',
-                //     style: AppTextStyles.bodyR.copyWith(
-                //       color: AppColors.textDefault,
-                //     ),
-                //   ),
-                // ),
               ],
             ),
           ),

--- a/lib/presentation/custom_jangdan/custom_jangdan_list_screen.dart
+++ b/lib/presentation/custom_jangdan/custom_jangdan_list_screen.dart
@@ -59,6 +59,7 @@ class CustomJangdanListScreen extends StatelessWidget {
                       );
                     },
                     child: ListTile(
+                      contentPadding: EdgeInsets.symmetric(horizontal: 16),
                       title: Container(
                         padding: const EdgeInsets.symmetric(
                           horizontal: 22,
@@ -141,6 +142,7 @@ class CustomJangdanListScreen extends StatelessWidget {
                     context.read<JangdanBloc>().add(DeleteJangdan(jangdan.name));
                   },
                   child: ListTile(
+                    contentPadding: EdgeInsets.symmetric(horizontal: 16),
                     title: Container(
                       padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 20),
                       decoration: BoxDecoration(

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -100,20 +100,23 @@ class HomeScreen extends StatelessWidget {
                   height: 84,
                   child:
                       customJangdanList.isEmpty
-                          ? Container(
-                            width: double.infinity,
-                            decoration: BoxDecoration(
-                              color: AppColors.backgroundSheet,
-                              borderRadius: BorderRadius.all(
-                                Radius.circular(16),
+                          ? Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 16),
+                            child: Container(
+                              width: double.infinity,
+                              decoration: BoxDecoration(
+                                color: AppColors.backgroundSheet,
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(16),
+                                ),
                               ),
-                            ),
-                            child: Center(
-                              child: Text(
-                                "저장한 장단이 없어요",
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  color: AppColors.textQuaternary,
+                              child: Center(
+                                child: Text(
+                                  "저장한 장단이 없어요",
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: AppColors.textQuaternary,
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -34,11 +34,11 @@ class HomeScreen extends StatelessWidget {
         ),
       ),
       body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Column(
-            children: [
-              GestureDetector(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: GestureDetector(
                 onTap: () async {
                   final Uri url = Uri.parse(
                     'https://forms.gle/aB7Rks3KDA8NP9yM7',
@@ -52,207 +52,214 @@ class HomeScreen extends StatelessWidget {
                   child: Image.asset("assets/images/banner/TestBanner.png"),
                 ),
               ),
+            ),
 
-              const SizedBox(height: 24),
+            const SizedBox(height: 24),
 
-              Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          "내가 저장한 장단",
-                          style: AppTextStyles.title2B.copyWith(
-                            color: AppColors.textDefault,
-                          ),
+            Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        "내가 저장한 장단",
+                        style: AppTextStyles.title2B.copyWith(
+                          color: AppColors.textDefault,
                         ),
-                        TextButton(
-                          onPressed: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => CustomJangdanListScreen(),
-                              ),
-                            );
-                          },
-                          style: TextButton.styleFrom(
-                            minimumSize: Size(40, 40),
-                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            padding: EdgeInsets.zero,
-                          ),
-                          child: Text(
-                            "더보기",
-                            style: AppTextStyles.calloutR.copyWith(
-                              color: AppColors.textTertiary,
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => CustomJangdanListScreen(),
                             ),
+                          );
+                        },
+                        style: TextButton.styleFrom(
+                          minimumSize: Size(40, 40),
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          padding: EdgeInsets.zero,
+                        ),
+                        child: Text(
+                          "더보기",
+                          style: AppTextStyles.calloutR.copyWith(
+                            color: AppColors.textTertiary,
                           ),
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
+                ),
 
-                  const SizedBox(height: 8),
+                const SizedBox(height: 8),
 
-                  SizedBox(
-                    height: 84,
-                    child:
-                        customJangdanList.isEmpty
-                            ? Container(
-                              width: double.infinity,
-                              decoration: BoxDecoration(
-                                color: AppColors.backgroundSheet,
-                                borderRadius: BorderRadius.all(
-                                  Radius.circular(16),
+                SizedBox(
+                  height: 84,
+                  child:
+                      customJangdanList.isEmpty
+                          ? Container(
+                            width: double.infinity,
+                            decoration: BoxDecoration(
+                              color: AppColors.backgroundSheet,
+                              borderRadius: BorderRadius.all(
+                                Radius.circular(16),
+                              ),
+                            ),
+                            child: Center(
+                              child: Text(
+                                "저장한 장단이 없어요",
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  color: AppColors.textQuaternary,
                                 ),
                               ),
-                              child: Center(
-                                child: Text(
-                                  "저장한 장단이 없어요",
-                                  style: TextStyle(
-                                    fontSize: 16,
-                                    color: AppColors.textQuaternary,
-                                  ),
-                                ),
-                              ),
-                            )
-                            : ListView.separated(
-                              scrollDirection: Axis.horizontal,
-                              itemCount:
-                                  customJangdanList.length >= 2
-                                      ? customJangdanList.length + 1
-                                      : customJangdanList.length,
-                              separatorBuilder:
-                                  (context, index) => SizedBox(width: 8),
-                              itemBuilder: (context, index) {
-                                if (customJangdanList.length >= 2 &&
-                                    index == customJangdanList.length) {
-                                  return InkWell(
-                                    onTap: () {
-                                      Navigator.push(
-                                        context,
-                                        MaterialPageRoute(
-                                          builder:
-                                              (context) =>
-                                                  CustomJangdanListScreen(),
-                                        ),
-                                      );
-                                    },
-                                    child: Container(
-                                      width: 156,
-                                      height: 84,
-                                      decoration: BoxDecoration(
-                                        color: AppColors.backgroundSheet,
-                                        borderRadius: BorderRadius.all(
-                                          Radius.circular(16),
-                                        ),
+                            ),
+                          )
+                          : ListView.separated(
+                            padding: EdgeInsets.symmetric(horizontal: 16),
+                            scrollDirection: Axis.horizontal,
+                            itemCount:
+                                customJangdanList.length >= 2
+                                    ? customJangdanList.length + 1
+                                    : customJangdanList.length,
+                            separatorBuilder:
+                                (context, index) => SizedBox(width: 8),
+                            itemBuilder: (context, index) {
+                              if (customJangdanList.length >= 2 &&
+                                  index == customJangdanList.length) {
+                                return InkWell(
+                                  onTap: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder:
+                                            (context) =>
+                                                CustomJangdanListScreen(),
                                       ),
-                                      child: Center(
-                                        child: Text(
-                                          "더보기",
-                                          style: TextStyle(
-                                            fontSize: 17,
-                                            color: AppColors.textTertiary,
-                                          ),
+                                    );
+                                  },
+                                  child: Container(
+                                    width: 156,
+                                    height: 84,
+                                    decoration: BoxDecoration(
+                                      color: AppColors.backgroundSheet,
+                                      borderRadius: BorderRadius.all(
+                                        Radius.circular(16),
+                                      ),
+                                    ),
+                                    child: Center(
+                                      child: Text(
+                                        "더보기",
+                                        style: TextStyle(
+                                          fontSize: 17,
+                                          color: AppColors.textTertiary,
                                         ),
                                       ),
                                     ),
-                                  );
-                                } else {
-                                  final item = customJangdanList[index];
-                                  return InkWell(
-                                    onTap: () {
-                                      context.read<MetronomeBloc>().add(
-                                        SelectJangdan(item),
-                                      );
-                                      Navigator.push(
-                                        context,
-                                        MaterialPageRoute(
-                                          builder:
-                                              (context) => MetronomeScreen(
-                                                jangdan: item,
-                                                appBarMode: AppBarMode.custom,
-                                              ),
-                                        ),
-                                      );
-                                    },
-                                    child: Container(
-                                      width: 156,
-                                      height: 84,
-                                      padding: EdgeInsets.symmetric(
-                                        horizontal: 16,
+                                  ),
+                                );
+                              } else {
+                                final item = customJangdanList[index];
+                                return InkWell(
+                                  onTap: () {
+                                    context.read<MetronomeBloc>().add(
+                                      SelectJangdan(item),
+                                    );
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder:
+                                            (context) => MetronomeScreen(
+                                              jangdan: item,
+                                              appBarMode: AppBarMode.custom,
+                                            ),
                                       ),
-                                      clipBehavior: Clip.hardEdge,
-                                      decoration: BoxDecoration(
-                                        color: AppColors.backgroundSheet,
-                                        borderRadius: BorderRadius.all(
-                                          Radius.circular(16),
-                                        ),
+                                    );
+                                  },
+                                  child: Container(
+                                    width: 156,
+                                    height: 84,
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: 16,
+                                    ),
+                                    clipBehavior: Clip.hardEdge,
+                                    decoration: BoxDecoration(
+                                      color: AppColors.backgroundSheet,
+                                      borderRadius: BorderRadius.all(
+                                        Radius.circular(16),
                                       ),
-                                      child: Stack(
-                                        alignment: Alignment.center,
-                                        children: [
-                                          Positioned.fill(
-                                            child: OverflowBox(
-                                              maxWidth: double.infinity,
-                                              maxHeight: double.infinity,
-                                              child: Transform.translate(
-                                                offset: Offset(0, 110),
-                                                child: Container(
-                                                  width: 300,
-                                                  height: 300,
-                                                  decoration: BoxDecoration(
-                                                    shape: BoxShape.circle,
-                                                    gradient: RadialGradient(
-                                                      radius: 1.0,
-                                                      center: Alignment.center,
-                                                      colors: [
-                                                        AppColors.bakBarActiveTop,
-                                                        AppColors.backgroundCard.withAlpha(0),
-                                                      ],
-                                                      stops: [0, 0.5],
-                                                    ),
+                                    ),
+                                    child: Stack(
+                                      alignment: Alignment.center,
+                                      children: [
+                                        Positioned.fill(
+                                          child: OverflowBox(
+                                            maxWidth: double.infinity,
+                                            maxHeight: double.infinity,
+                                            child: Transform.translate(
+                                              offset: Offset(0, 110),
+                                              child: Container(
+                                                width: 300,
+                                                height: 300,
+                                                decoration: BoxDecoration(
+                                                  shape: BoxShape.circle,
+                                                  gradient: RadialGradient(
+                                                    radius: 1.0,
+                                                    center: Alignment.center,
+                                                    colors: [
+                                                      AppColors.bakBarActiveTop,
+                                                      AppColors.backgroundCard
+                                                          .withAlpha(0),
+                                                    ],
+                                                    stops: [0, 0.5],
                                                   ),
                                                 ),
                                               ),
                                             ),
                                           ),
-                                          Column(
-                                            mainAxisAlignment: MainAxisAlignment.center,
-                                            children: [
-                                              Text(
-                                                item.name,
-                                                maxLines: 1,
-                                                overflow: TextOverflow.ellipsis,
-                                                style: TextStyle(
-                                                  fontSize: 17,
-                                                  color: AppColors.textDefault,
-                                                ),
+                                        ),
+                                        Column(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                          children: [
+                                            Text(
+                                              item.name,
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
+                                              style: TextStyle(
+                                                fontSize: 17,
+                                                color: AppColors.textDefault,
                                               ),
-                                              Text(
-                                                item.jangdanType.label,
-                                                style: TextStyle(
-                                                  fontSize: 15,
-                                                  color: AppColors.textTertiary,
-                                                ),
+                                            ),
+                                            Text(
+                                              item.jangdanType.label,
+                                              style: TextStyle(
+                                                fontSize: 15,
+                                                color: AppColors.textTertiary,
                                               ),
-                                            ],
-                                          ),
-                                        ],
-                                      ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
                                     ),
-                                  );
-                                }
-                              },
-                            ),
-                  ),
-                ],
-              ), //내가 저장한 장단 끝
+                                  ),
+                                );
+                              }
+                            },
+                          ),
+                ),
+              ],
+            ),
 
-              SizedBox(height: 32),
+            //내가 저장한 장단 끝
+            const SizedBox(height: 32),
 
-              Column(
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
                 children: [
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 4),
@@ -351,7 +358,7 @@ class HomeScreen extends StatelessWidget {
                                         ),
                                       ),
 
-                                      const SizedBox(height: 4,),
+                                      const SizedBox(height: 4),
 
                                       Text(
                                         jangdan.bakInformation,
@@ -377,10 +384,10 @@ class HomeScreen extends StatelessWidget {
                   ),
                 ],
               ),
+            ),
 
-              const SizedBox(height: 80),
-            ],
-          ),
+            const SizedBox(height: 80),
+          ],
         ),
       ),
     );

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -114,7 +114,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                   ),
                   PopupMenuItem(
                     value: 'save',
-                    child: Text('장단 내보내기', style: AppTextStyles.bodyR),
+                    child: Text('다른 이름으로 저장', style: AppTextStyles.bodyR),
                   ),
                   PopupMenuItem(
                     value: 'rename',

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -28,6 +28,7 @@ class MetronomeScreen extends StatefulWidget {
 
 class _MetronomeScreenState extends State<MetronomeScreen> {
   bool _showFlashOverlay = false;
+  bool _awaitingSave = false;
 
   String get appBarTitle {
     final selected = context.watch<MetronomeBloc>().state.selectedJangdan;
@@ -71,7 +72,8 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                         child: Text('취소'),
                       ),
                       TextButton(
-                        onPressed: () => Navigator.pop(context, controller.text),
+                        onPressed:
+                            () => Navigator.pop(context, controller.text),
                         child: Text('저장'),
                       ),
                     ],
@@ -80,8 +82,11 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
               );
 
               if (result != null && result.trim().isNotEmpty) {
-                final selectedJangdan = context.read<MetronomeBloc>().state.selectedJangdan;
-                final updatedJangdan = selectedJangdan.copyWith(name: result.trim());
+                final selectedJangdan =
+                    context.read<MetronomeBloc>().state.selectedJangdan;
+                final updatedJangdan = selectedJangdan.copyWith(
+                  name: result.trim(),
+                );
                 context.read<JangdanBloc>().add(AddJangdan(updatedJangdan));
               }
             },
@@ -97,66 +102,75 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
           ),
           PopupMenuButton<String>(
             icon: Icon(Icons.pending_outlined),
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
             color: AppColors.backgroundPopupMenu,
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'update',
-                child: Text('장단 저장하기', style: AppTextStyles.bodyR),
-              ),
-              PopupMenuItem(
-                value: 'save',
-                child: Text('장단 내보내기', style: AppTextStyles.bodyR),
-              ),
-              PopupMenuItem(
-                value: 'rename',
-                child: Text('장단 이름 변경하기', style: AppTextStyles.bodyR),
-              ),
-              PopupMenuItem(
-                value: 'delete',
-                child: Text('장단 삭제하기', style: AppTextStyles.bodyR),
-              ),
-            ],
+            itemBuilder:
+                (context) => [
+                  PopupMenuItem(
+                    value: 'update',
+                    child: Text('장단 저장하기', style: AppTextStyles.bodyR),
+                  ),
+                  PopupMenuItem(
+                    value: 'save',
+                    child: Text('장단 내보내기', style: AppTextStyles.bodyR),
+                  ),
+                  PopupMenuItem(
+                    value: 'rename',
+                    child: Text('장단 이름 변경하기', style: AppTextStyles.bodyR),
+                  ),
+                  PopupMenuItem(
+                    value: 'delete',
+                    child: Text('장단 삭제하기', style: AppTextStyles.bodyR),
+                  ),
+                ],
             onSelected: (value) async {
               switch (value) {
                 case 'update':
-                  final updatedJangdan = context.read<MetronomeBloc>().state.selectedJangdan;
-                  context.read<JangdanBloc>().add(UpdateJangdan(updatedJangdan.name, updatedJangdan));
+                  final updatedJangdan =
+                      context.read<MetronomeBloc>().state.selectedJangdan;
+                  context.read<JangdanBloc>().add(
+                    UpdateJangdan(updatedJangdan.name, updatedJangdan),
+                  );
                   break;
                 case 'save':
-                  final current = context.read<MetronomeBloc>().state.selectedJangdan;
+                  final current =
+                      context.read<MetronomeBloc>().state.selectedJangdan;
                   final controller = TextEditingController(text: '');
                   final result = await showDialog<String>(
                     context: context,
                     builder: (context) {
                       return AlertDialog(
                         title: Text('장단 이름 저장'),
-                          content: TextField(
-                            controller: controller,
-                            maxLength: 13,
-                            decoration: InputDecoration(hintText: '장단 이름을 입력하세요'),
-                          ),
+                        content: TextField(
+                          controller: controller,
+                          maxLength: 13,
+                          decoration: InputDecoration(hintText: '장단 이름을 입력하세요'),
+                        ),
                         actions: [
                           TextButton(
                             onPressed: () => Navigator.pop(context),
                             child: Text('취소'),
                           ),
                           TextButton(
-                            onPressed: () => Navigator.pop(context, controller.text),
+                            onPressed:
+                                () => Navigator.pop(context, controller.text),
                             child: Text('저장'),
                           ),
                         ],
                       );
                     },
                   );
-                  
+
                   if (result != null && result.trim().isNotEmpty) {
                     final duplicated = current.copyWith(name: result.trim());
                     context.read<JangdanBloc>().add(AddJangdan(duplicated));
                   }
                   break;
                 case 'rename':
-                  final current = context.read<MetronomeBloc>().state.selectedJangdan;
+                  final current =
+                      context.read<MetronomeBloc>().state.selectedJangdan;
                   final controller = TextEditingController(text: current.name);
                   final result = await showDialog<String>(
                     context: context,
@@ -166,7 +180,9 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                         content: TextField(
                           controller: controller,
                           maxLength: 13,
-                          decoration: InputDecoration(hintText: '새 장단 이름을 입력하세요'),
+                          decoration: InputDecoration(
+                            hintText: '새 장단 이름을 입력하세요',
+                          ),
                         ),
                         actions: [
                           TextButton(
@@ -174,24 +190,32 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                             child: Text('취소'),
                           ),
                           TextButton(
-                            onPressed: () => Navigator.pop(context, controller.text),
+                            onPressed:
+                                () => Navigator.pop(context, controller.text),
                             child: Text('변경'),
                           ),
                         ],
                       );
                     },
                   );
-                  
-                  if (result != null && result.trim().isNotEmpty && result.trim() != current.name) {
+
+                  if (result != null &&
+                      result.trim().isNotEmpty &&
+                      result.trim() != current.name) {
                     final updated = current.copyWith(name: result.trim());
                     context.read<JangdanBloc>().add(AddJangdan(updated));
                     context.read<MetronomeBloc>().add(SelectJangdan(updated));
-                    context.read<JangdanBloc>().add(DeleteJangdan(current.name));
+                    context.read<JangdanBloc>().add(
+                      DeleteJangdan(current.name),
+                    );
                   }
                   break;
                 case 'delete':
-                  final selectedJangdan = context.read<MetronomeBloc>().state.selectedJangdan;
-                  context.read<JangdanBloc>().add(DeleteJangdan(selectedJangdan.name));
+                  final selectedJangdan =
+                      context.read<MetronomeBloc>().state.selectedJangdan;
+                  context.read<JangdanBloc>().add(
+                    DeleteJangdan(selectedJangdan.name),
+                  );
                   Navigator.pop(context);
                   break;
               }
@@ -231,7 +255,8 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                         child: Text('취소'),
                       ),
                       TextButton(
-                        onPressed: () => Navigator.pop(context, controller.text),
+                        onPressed:
+                            () => Navigator.pop(context, controller.text),
                         child: Text('저장'),
                       ),
                     ],
@@ -240,11 +265,15 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
               );
 
               if (result != null && result.trim().isNotEmpty) {
-                final selectedJangdan = context.read<MetronomeBloc>().state.selectedJangdan;
-                final updatedJangdan = selectedJangdan.copyWith(name: result.trim());
+                final selectedJangdan =
+                    context.read<MetronomeBloc>().state.selectedJangdan;
+                final updatedJangdan = selectedJangdan.copyWith(
+                  name: result.trim(),
+                );
+                setState(() {
+                  _awaitingSave = true;
+                });
                 context.read<JangdanBloc>().add(AddJangdan(updatedJangdan));
-                Navigator.pop(context);
-                Navigator.pop(context);
               }
             },
             child: Text(
@@ -258,7 +287,6 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-
     // 화면 반짝임 기능
     return MultiBlocListener(
       listeners: [
@@ -279,19 +307,30 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
         BlocListener<JangdanBloc, JangdanState>(
           listener: (context, state) {
             if (state is JangdanError) {
+              setState(() {
+                _awaitingSave = false;
+              });
               showDialog(
                 context: context,
-                builder: (_) => AlertDialog(
-                  title: Text('저장 실패'),
-                  content: Text('이미 등록된 장단 이름입니다.\n다른 이름으로 다시 시도해주세요.'),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context),
-                      child: Text('확인'),
+                builder:
+                    (_) => AlertDialog(
+                      title: Text('저장 실패'),
+                      content: Text('이미 등록된 장단 이름입니다.\n다른 이름으로 다시 시도해주세요.'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context),
+                          child: Text('확인'),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
               );
+              context.read<JangdanBloc>().add(LoadJangdan());
+            } else if (state is JangdanLoaded && _awaitingSave) {
+              setState(() {
+                _awaitingSave = false;
+              });
+              Navigator.pop(context);
+              Navigator.pop(context);
             }
           },
         ),
@@ -314,11 +353,13 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                   onPressed: () {
                     Navigator.pop(context);
                   },
-                  icon: Icon(Icons.chevron_left, color: AppColors.textDefault,),
+                  icon: Icon(Icons.chevron_left, color: AppColors.textDefault),
                 ),
                 title: Text(
                   appBarTitle,
-                  style: AppTextStyles.bodyR.copyWith(color: AppColors.textSecondary),
+                  style: AppTextStyles.bodyR.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
                 ),
                 centerTitle: true,
                 actions: appBarActions,
@@ -327,7 +368,9 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                 builder: (context, constraints) {
                   return SingleChildScrollView(
                     child: ConstrainedBox(
-                      constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
                       child: IntrinsicHeight(
                         child: Column(
                           children: [
@@ -335,7 +378,9 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                               builder: (context, state) => HanbaeBoard(),
                             ),
                             Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16.0,
+                              ),
                               child: MetronomeOptions(),
                             ),
                             BlocBuilder<MetronomeBloc, MetronomeState>(
@@ -356,9 +401,10 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
               ignoring: !_showFlashOverlay,
               child: AnimatedOpacity(
                 opacity: _showFlashOverlay ? 1.0 : 0.0,
-                duration: _showFlashOverlay
-                    ? Duration.zero
-                    : const Duration(milliseconds: 300),
+                duration:
+                    _showFlashOverlay
+                        ? Duration.zero
+                        : const Duration(milliseconds: 300),
                 curve: Curves.linear,
                 child: Container(color: AppColors.blink),
               ),

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -63,7 +63,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                     title: Text('장단 이름 저장'),
                     content: TextField(
                       controller: controller,
-                      maxLength: 13,
+                      maxLength: 10,
                       decoration: InputDecoration(hintText: '장단 이름을 입력하세요'),
                     ),
                     actions: [
@@ -145,7 +145,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                         title: Text('장단 이름 저장'),
                         content: TextField(
                           controller: controller,
-                          maxLength: 13,
+                          maxLength: 10,
                           decoration: InputDecoration(hintText: '장단 이름을 입력하세요'),
                         ),
                         actions: [
@@ -179,7 +179,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                         title: Text('장단 이름 변경'),
                         content: TextField(
                           controller: controller,
-                          maxLength: 13,
+                          maxLength: 10,
                           decoration: InputDecoration(
                             hintText: '새 장단 이름을 입력하세요',
                           ),
@@ -246,7 +246,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                     title: Text('장단 이름 저장'),
                     content: TextField(
                       controller: controller,
-                      maxLength: 13,
+                      maxLength: 10,
                       decoration: InputDecoration(hintText: '장단 이름을 입력하세요'),
                     ),
                     actions: [
@@ -349,12 +349,6 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
             child: Scaffold(
               appBar: AppBar(
                 toolbarHeight: 44.0,
-                // leading: IconButton(
-                //   onPressed: () {
-                //     Navigator.pop(context);
-                //   },
-                //   icon: Icon(Icons.chevron_left, color: AppColors.textDefault),
-                // ),
                 title: Text(
                   appBarTitle,
                   style: AppTextStyles.bodyR.copyWith(

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -349,12 +349,12 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
             child: Scaffold(
               appBar: AppBar(
                 toolbarHeight: 44.0,
-                leading: IconButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                  icon: Icon(Icons.chevron_left, color: AppColors.textDefault),
-                ),
+                // leading: IconButton(
+                //   onPressed: () {
+                //     Navigator.pop(context);
+                //   },
+                //   icon: Icon(Icons.chevron_left, color: AppColors.textDefault),
+                // ),
                 title: Text(
                   appBarTitle,
                   style: AppTextStyles.bodyR.copyWith(

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -54,7 +54,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
           IconButton(
             icon: Icon(Icons.download),
             onPressed: () async {
-              final controller = TextEditingController(text: widget.jangdan.name);
+              final controller = TextEditingController(text: '');
               final result = await showDialog<String>(
                 context: context,
                 builder: (context) {
@@ -125,7 +125,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                   break;
                 case 'save':
                   final current = context.read<MetronomeBloc>().state.selectedJangdan;
-                  final controller = TextEditingController(text: current.name);
+                  final controller = TextEditingController(text: '');
                   final result = await showDialog<String>(
                     context: context,
                     builder: (context) {
@@ -213,8 +213,7 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
               minimumSize: Size(40, 40),
             ),
             onPressed: () async {
-              String newName = widget.jangdan.name;
-              final controller = TextEditingController(text: newName);
+              final controller = TextEditingController(text: '');
 
               final result = await showDialog<String>(
                 context: context,


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
커스텀 장단 관련 디테일한 수정사항들을 1차적으로 반영합니다.

<!-- Close #89  -->

## 작업 내용
### 1. 장단 저장 팝업
- 기본값 빈칸
- 최대 10글자

### 2. 중복 장단 에러처리
- 에러 발생시 메트로놈 스크린에서 벗어나지 않게 변경
- 에러 발생하더라도 다시 장단 목록이 정상적으로 보이게 수정

### 3. UI개선
- Home 화면 가로스크롤 좌우 패딩 삭제
- 커스텀장단 리스트 좌우 패딩 기본값 설정해서 균일하게 변경
- Appbar 높이 44로 고정
- Appbar 뒤로가기 버튼 Android 내장 기본값 사용
- 장단 내보내기 -> 다른 이름으로 저장 명칭 변경

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?