### PR TITLE
[Fix] #95 BPM 변경사항이 커스텀 되도록

### DIFF
--- a/lib/bloc/metronome/metronome_bloc.dart
+++ b/lib/bloc/metronome/metronome_bloc.dart
@@ -122,7 +122,7 @@ class MetronomeBloc extends Bloc<MetronomeEvent, MetronomeState> {
     on<ChangeBpm>((event, emit) {
       add(const StopTapping());
       final newBpm = (state.bpm + event.delta).clamp(10, 300);
-      emit(state.copyWith(bpm: newBpm));
+      emit(state.copyWith(selectedJangdan: state.selectedJangdan.copyWith(bpm: newBpm), bpm: newBpm));
     });
 
     on<ChangeSound>((event, emit) { // Add new event handler

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+1
+version: 1.1.0+10
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
BPM 변경사항이 커스텀 장단에는 저장되지 않는 이슈를 수정합니다.

<!-- Close #95  -->

## 작업 내용
### 1. BPM 변경사항 반영
- 기존 state에서 bpm을 따로 관리하고 있었음
- bpm 변경시 selectedjangdan에 반영되지 않음
- 따라서 bpm은 selectedjangdan을 저장할 때 함께 저장되지 않음
- bpm 변경마다 selectedjangdan에 반영되도록 변경

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?