### PR TITLE
[Feat] #101 더미 사운드 재생

### DIFF
--- a/android/app/src/main/kotlin/krabs/hanbae/MainActivity.kt
+++ b/android/app/src/main/kotlin/krabs/hanbae/MainActivity.kt
@@ -27,6 +27,13 @@ class MainActivity : FlutterActivity() {
             .setMaxStreams(10)
             .build()
 
+        soundPool.setOnLoadCompleteListener { pool, sampleId, status ->
+            if (status == 0) { // Load success
+                pool.play(sampleId, 0f, 0f, 1, 0, 1f)
+                Log.d("SoundManager", "Silent sound played for initialization.")
+            }
+        }
+
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "play" -> {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hanbae/bloc/metronome/metronome_bloc.dart';
-import 'package:hanbae/model/sound.dart';
 import 'package:hanbae/presentation/home/home_screen.dart';
 import 'package:hanbae/theme/colors.dart';
 import 'package:hanbae/data/sound_manager.dart';
@@ -22,7 +21,6 @@ void main() async {
   await Hive.openBox<Jangdan>('customJangdanBox');
 
   await SoundManager.preloadAllSounds();
-  await SoundManager.play(Sound.clave, Accent.none);
 
   final jangdanRepository = JangdanRepository();
 


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
메트로놈 재생 전에 미리 소리 에셋을 재생해서 예열시킵니다

<!-- Close #101  -->

## 작업 내용
### 1. 오디오 컨트롤러 예열
- 소리 에셋 load 되면 볼륨 0으로 한번씩 재생해서 오디오 컨트롤러 예열

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?