### PR TITLE
[Feat] #138 절화 label, 커스텀장단카드 폰트

### DIFF
--- a/lib/data/basic_jangdan_data.dart
+++ b/lib/data/basic_jangdan_data.dart
@@ -285,7 +285,7 @@ List<Jangdan> basicJangdanList = [
     ],
   ),
   Jangdan(
-    name: "절화",
+    name: "절화(길군악)",
     createdAt: DateTime.now(),
     jangdanType: JangdanType.chwita,
     bpm: 60,

--- a/lib/model/jangdan_type.dart
+++ b/lib/model/jangdan_type.dart
@@ -66,7 +66,7 @@ extension JangdanTypeExtension on JangdanType {
       case JangdanType.seryeongsan: return "세령산, 가락덜이";
       case JangdanType.taryeong: return "타령, 군악";
       case JangdanType.chwita: return "취타";
-      case JangdanType.jeolhwa: return "절화";
+      case JangdanType.jeolhwa: return "절화(길군악)";
       case JangdanType.ginyeombul: return "긴염불";
       case JangdanType.banyeombul: return "반염불";
     }

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -247,20 +247,19 @@ class HomeScreen extends StatelessWidget {
                                         Column(
                                           mainAxisAlignment:
                                               MainAxisAlignment.center,
+                                          spacing: 2,
                                           children: [
                                             Text(
                                               item.name,
                                               maxLines: 1,
                                               overflow: TextOverflow.ellipsis,
-                                              style: TextStyle(
-                                                fontSize: 17,
+                                              style: AppTextStyles.headlineSb.copyWith(
                                                 color: AppColors.labelDefault,
                                               ),
                                             ),
                                             Text(
                                               item.jangdanType.label,
-                                              style: TextStyle(
-                                                fontSize: 15,
+                                              style: AppTextStyles.subheadlineR.copyWith(
                                                 color: AppColors.labelSecondary,
                                               ),
                                             ),


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #138 -->

## 작업 내용
### 1. 절화 label
- 절화 -> 절화(길군악) 병기

### 2. 커스텀장단 폰트
- 장단 이름은 headlineSB
- 장단 종류는 subHeadlineR
- 사이 간격 2 추가

## 비고 <!-- (Optional) -->
폰트 사이즈는 기존과 달라졌지만 원래 의도인 AppTextStyle만 변경하면 같이 변경되도록 색상만 copyWith로 수정

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?