### PR TITLE
[Fix] #140 예비박 진행중 소박보기 비활성화

### DIFF
--- a/lib/presentation/metronome/hanbae_board.dart
+++ b/lib/presentation/metronome/hanbae_board.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hanbae/model/accent.dart';
 import 'package:flutter_bloc/flutter_bloc.dart'; // Import the flutter_bloc package
 import 'package:hanbae/bloc/metronome/metronome_bloc.dart';
@@ -15,10 +12,6 @@ class HanbaeBoard extends StatelessWidget {
   Widget build(BuildContext context) {
     final jangdan = context.select(
       (MetronomeBloc bloc) => bloc.state.selectedJangdan,
-    );
-
-    final isPlaying = context.select(
-      (MetronomeBloc bloc) => bloc.state.isPlaying,
     );
 
     final reserveBeat = context.select(

--- a/lib/presentation/metronome/hanbae_board.dart
+++ b/lib/presentation/metronome/hanbae_board.dart
@@ -126,6 +126,9 @@ class SobakSegment extends StatelessWidget {
     final isSobakOn = context.select(
       (MetronomeBloc bloc) => bloc.state.isSobakOn,
     );
+    final reserveBeat = context.select(
+      (MetronomeBloc bloc) => bloc.state.reserveBeatTime,
+    );
     final isPlaying = context.select(
       (MetronomeBloc bloc) => bloc.state.isPlaying,
     );
@@ -154,16 +157,13 @@ class SobakSegment extends StatelessWidget {
                     return Expanded(
                       child: Container(
                         decoration: BoxDecoration(
-                          color:
-                              isSobakOn
-                                  ? isPlaying
-                                      ? activedSobak * 2 == index
-                                          ? index == 0
-                                              ? AppColors.sobakSegmentDaebak
-                                              : AppColors.sobakSegmentSobak
-                                          : AppColors.frame
-                                      : AppColors.frame
-                                  : AppColors.frame,
+                          color: !isSobakOn || !isPlaying || reserveBeat != 0
+                                ? AppColors.frame
+                                : (activedSobak * 2 == index
+                                    ? (index == 0
+                                        ? AppColors.sobakSegmentDaebak
+                                        : AppColors.sobakSegmentSobak)
+                                    : AppColors.frame),
                         ),
                       ),
                     );


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #140  -->

## 작업 내용
### 1. 소박보기 색상 조건값 수정
- 중첩 삼항연산자 대신 좀 더 보기 편하게
- reserveBeat 카운트가 0이 아닌경우에만 색상 표시되도록 조건 추가

### 2. 경고 수정
- 안쓰는 패키지, 안쓰는 코드 삭제

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?