### PR TITLE
[Fix] #144 BakBar 구조 개선

### DIFF
--- a/lib/presentation/metronome/hanbae_board.dart
+++ b/lib/presentation/metronome/hanbae_board.dart
@@ -317,7 +317,6 @@ class Bakbar extends StatelessWidget {
     final isPlaying = context.select(
       (MetronomeBloc bloc) => bloc.state.isPlaying,
     );
-    final height = MediaQuery.of(context).size.height;
 
     return GestureDetector(
       onTap: () {

--- a/lib/presentation/metronome/hanbae_board.dart
+++ b/lib/presentation/metronome/hanbae_board.dart
@@ -349,9 +349,9 @@ class Bakbar extends StatelessWidget {
             // 주황 박스
             Align(
               alignment: Alignment.bottomCenter,
-              child: ConstrainedBox(
-                constraints: BoxConstraints(maxHeight: height * fillFraction),
-                child: FractionallySizedBox(
+              child: fillFraction == 0
+              ? SizedBox.shrink()
+              : FractionallySizedBox(
                   heightFactor: fillFraction,
                   widthFactor: 1.0,
                   child: Container(
@@ -361,7 +361,6 @@ class Bakbar extends StatelessWidget {
                     ),
                   ),
                 ),
-              ),
             ),
 
             // 상단 숫자


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
BakBar의 .weak 높이가 의도하지 않은 대로 나타나는 문제

<!-- Close #144 -->

## 작업 내용
### 1. 위젯 중첩 제거
- FractionallySizedBox에서 이미 fillFraction으로 높이를 계산하고 있었음
- ConstrainedBox로 한번 더 높이를 계산함
- 둘 사이에서 충돌이 발생할 가능성

### 2. Crash
- 기존에 중첩시킨 이유는 Accent가 .none일 때 크래시가 발생하기 때문
- fillFraction이 0이 되는 바람에 FractionallySizedBox에서 오류가 발생한게 아닐까 추정
- fillFraction이 0인 경우 그냥 비어있는 박스로 갈아치워서 해결

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?