### PR TITLE
[Feat] #173 신규장단 생성 화면에서 최근 재생에 추가 방지

### DIFF
--- a/lib/bloc/metronome/metronome_bloc.dart
+++ b/lib/bloc/metronome/metronome_bloc.dart
@@ -3,6 +3,7 @@ import 'package:equatable/equatable.dart';
 import 'package:hanbae/main.dart';
 import 'package:hanbae/model/accent.dart';
 import 'package:hanbae/model/jangdan_type.dart';
+import 'package:hanbae/presentation/metronome/metronome_screen.dart';
 import 'package:hanbae/utils/local_storage.dart';
 import 'package:hive/hive.dart';
 import 'dart:async';
@@ -111,7 +112,9 @@ class MetronomeBloc extends Bloc<MetronomeEvent, MetronomeState> {
         WakelockPlus.enable();
       }
 
-      Storage().addRecentJangdan(jangdan.name);
+      if (event.appState != AppBarMode.create) {
+        Storage().addRecentJangdan(jangdan.name);
+      }
     });
 
     on<Tick>((event, emit) async {

--- a/lib/bloc/metronome/metronome_event.dart
+++ b/lib/bloc/metronome/metronome_event.dart
@@ -16,7 +16,8 @@ class SelectJangdan extends MetronomeEvent {
 }
 
 class Play extends MetronomeEvent {
-  const Play();
+  final AppBarMode appState;
+  const Play({this.appState = AppBarMode.builtin});
 }
 
 class Tick extends MetronomeEvent {}

--- a/lib/presentation/metronome/metronome_control.dart
+++ b/lib/presentation/metronome/metronome_control.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hanbae/presentation/metronome/metronome_screen.dart';
 import 'package:hanbae/theme/colors.dart';
 import 'package:hanbae/theme/text_styles.dart';
 import 'package:flutter_bloc/flutter_bloc.dart'; // Import the flutter_bloc package
@@ -8,7 +9,12 @@ import 'dart:async';
 
 class MetronomeControl extends StatefulWidget {
   final double iconSize;
-  const MetronomeControl({super.key, required this.iconSize});
+  final AppBarMode appBarMode;
+  const MetronomeControl({
+    super.key,
+    required this.iconSize,
+    this.appBarMode = AppBarMode.builtin,
+  });
 
   @override
   _MetronomeControlState createState() => _MetronomeControlState();
@@ -228,7 +234,7 @@ class _MetronomeControlState extends State<MetronomeControl> {
                     key: const ValueKey('min_play_button'),
                     onPressed: () {
                       context.read<MetronomeBloc>().add(
-                        isPlaying ? Stop() : Play(),
+                        isPlaying ? Stop() : Play(appState: widget.appBarMode),
                       );
                     },
                     style: ElevatedButton.styleFrom(
@@ -253,7 +259,7 @@ class _MetronomeControlState extends State<MetronomeControl> {
                     key: const ValueKey('main_play_button'),
                     onPressed: () {
                       context.read<MetronomeBloc>().add(
-                        isPlaying ? Stop() : Play(),
+                        isPlaying ? Stop() : Play(appState: widget.appBarMode),
                       );
                     },
                     style: ElevatedButton.styleFrom(

--- a/lib/presentation/metronome/metronome_screen.dart
+++ b/lib/presentation/metronome/metronome_screen.dart
@@ -31,14 +31,12 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
   bool _awaitingSave = false;
 
   @override
-
   @override
   void deactivate() {
     if (context.read<MetronomeBloc>().state.minimum)
       context.read<MetronomeBloc>().add(const ToggleMinimum());
     super.deactivate();
   }
-
 
   String get appBarTitle {
     final selected = context.watch<MetronomeBloc>().state.selectedJangdan;
@@ -496,7 +494,10 @@ class _MetronomeScreenState extends State<MetronomeScreen> {
                                               .minimum
                                           ? 16
                                           : 32;
-                                  return MetronomeControl(iconSize: iconSize);
+                                  return MetronomeControl(
+                                    iconSize: iconSize,
+                                    appBarMode: widget.appBarMode,
+                                  );
                                 },
                               ),
                             ],


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #173  -->

## 작업 내용
### 1. AppbarMode
- 기존에 AppbarMode라는 열거형으로 메트로놈 화면을 구분하고 있었음 builtin / custom / create
- 재생 동작은 MetronomeControlScreen 에서 시키고 있기 때문에
- MetronomeScreen 에 있는 appbarMode를 ControlScreen 까지 넘겨줌
- 동시에 Play() 이벤트가 appbarMode를 인자로 받도록 수정
- Play() 이벤트 내부에서 인자로 받은 appbarMode 에 따라 최근 재생 장단에 추가

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?