### PR TITLE
[Feat] #177 최근장단 저장한도 해제

### DIFF
--- a/lib/utils/local_storage.dart
+++ b/lib/utils/local_storage.dart
@@ -38,7 +38,7 @@ class Storage {
     final updated = [name, ...recent.where((e) => e != name)];
 
     // 최대 3개까지만 유지
-    await setRecentJangdanNames(updated.take(3).toList());
+    await setRecentJangdanNames(updated);
   }
   
   Future<void> removeRecentJangdan(String name) async {


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

<!-- Close #177  -->

## 작업 내용
### 1. 최근장단 저장한도 해제
- 커스텀을 삭제하더라도 최근장단 3개 유지되도록 장단을 3개 이상 저장하도록 변경

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->

## CheckList <!-- 리뷰어가 체크할 항목입니다. -->
- [ ] PR의 Target이 올바르게 설정되어 있나요?
- [ ] Assignee는 올바르게 할당되어있나요?
- [ ] Label이 적절하게 설정되어 있나요?
- [ ] 변경사항에 의문이 드는 곳은 없나요?